### PR TITLE
Transform filename encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ import (
 	"os"
 
 	"github.com/kmtr/zip"
+	"golang.org/x/text/encoding/japanese"
 )
 
 func main() {
@@ -38,7 +39,8 @@ func main() {
 	}
 	zipw := zip.NewWriter(fzip)
 	defer zipw.Close()
-	w, err := zipw.Encrypt(`test.txt`, `golang`, zip.AES256Encryption)
+	zipw.FileNameTransformer = japanese.ShiftJIS.NewEncoder()
+	w, err := zipw.Encrypt(`日本語.txt`, `golang`, zip.StandardEncryption)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/yeka/zip"
+	"github.com/kmtr/zip"
 )
 
 func main() {
@@ -60,7 +60,7 @@ import (
 	"io/ioutil"
 	"log"
 
-	"github.com/yeka/zip"
+	"github.com/kmtr/zip"
 )
 
 func main() {

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -56,7 +56,7 @@ func TestPasswordHelloWorldAes(t *testing.T) {
 	var b bytes.Buffer
 	for _, f := range r.File {
 		if !f.IsEncrypted() {
-			t.Errorf("Expected %s to be encrypted.", f.FileInfo().Name)
+			t.Errorf("Expected %s to be encrypted.", f.FileInfo().Name())
 		}
 		f.SetPassword("golang")
 		rc, err := f.Open()

--- a/encoding.go
+++ b/encoding.go
@@ -1,0 +1,18 @@
+package zip
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"golang.org/x/text/transform"
+)
+
+func encodeText(str string, t transform.Transformer) (string, error) {
+	iostr := strings.NewReader(str)
+	rio := transform.NewReader(iostr, t)
+	ret, err := ioutil.ReadAll(rio)
+	if err != nil {
+		return "", err
+	}
+	return string(ret), nil
+}

--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/yeka/zip"
+	"github.com/kmtr/zip"
 )
 
 func ExampleWriter() {


### PR DESCRIPTION
Windowsでzipファイルの中のファイル名が文字化けしてしまうことに対応するために、
`zip.Writer` に `FileNameTransformer transform.Transformer` を追加。
`golang.org/x/text/transform` の `Transformer` がここに設定されていれば、
それを利用してファイル名のエンコードを行う。
例えばShift_JISでエンコードしたい場合は、`japanese.ShiftJIS.NewEncoder()` を設定する。


参考
golang.org/x/text/transform
golang.org/x/text/encoding/japanese